### PR TITLE
Add a form sheet manager singleton to use subclass in storyboards

### DIFF
--- a/MZFormSheetController/MZFormSheetController.h
+++ b/MZFormSheetController/MZFormSheetController.h
@@ -72,11 +72,21 @@ typedef void(^MZFormSheetBackgroundViewTapCompletionHandler)(CGPoint location);
 typedef void(^MZFormSheetPresentationCompletionHandler)(MZFormSheetController *formSheetController);
 typedef void(^MZFormSheetTransitionCompletionHandler)();
 
+@interface MZFormSheetManager : NSObject
++ (instancetype)sharedManager;
+@property (strong, nonatomic) Class formSheetControllerClass;
+@end
+
 @interface MZFormSheetController : UIViewController <UIAppearance>
 /**
  Return copy of formSheetController stack, last object (form sheet controller) is at the top
  */
 + (NSArray *)formSheetControllersStack;
+
+/**
+ Return the shared manager that handle basic configurations
+ */
++ (MZFormSheetManager *)manager;
 
 /**
  The view controller that is presented by this form sheet controller.

--- a/MZFormSheetController/MZFormSheetController.m
+++ b/MZFormSheetController/MZFormSheetController.m
@@ -216,6 +216,32 @@ static NSMutableDictionary *instanceOfDictionaryClasses = nil;
 
 @end
 
+#pragma mark - MZFormSheetManager
+
+@implementation MZFormSheetManager
+
++ (instancetype)sharedManager {
+    static MZFormSheetManager *_sharedManager = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        _sharedManager = [[MZFormSheetManager alloc] init];
+    });
+    
+    return _sharedManager;
+}
+
+- (Class)defaultFormSheetControllerClass
+{
+    Class cls = [self formSheetControllerClass];
+    if (cls == nil) {
+        return [MZFormSheetController class];
+    }
+    
+    return cls;
+}
+
+@end
+
 #pragma mark - MZFormSheetController
 
 @interface MZFormSheetController () <UIGestureRecognizerDelegate>
@@ -927,7 +953,8 @@ static NSMutableDictionary *instanceOfDictionaryClasses = nil;
 
 - (void)presentFormSheetWithViewController:(UIViewController *)viewController animated:(BOOL)animated transitionStyle:(MZFormSheetTransitionStyle)transitionStyle completionHandler:(MZFormSheetPresentationCompletionHandler)completionHandler
 {
-    MZFormSheetController *formSheet = [[MZFormSheetController alloc] initWithViewController:viewController];
+    Class formSheetClass = [[MZFormSheetManager sharedManager] defaultFormSheetControllerClass];
+    MZFormSheetController *formSheet = [[formSheetClass alloc] initWithViewController:viewController];
     self.formSheetController = formSheet;
     viewController.formSheetController = formSheet;
     


### PR DESCRIPTION
Because the [`presentFormSheetWithViewController:animated:transitionStyle:completionHandler:`](https://github.com/m1entus/MZFormSheetController/blob/master/MZFormSheetController/MZFormSheetController.m#L930) method wasn't able to use the subclass I've created to support custom animations.

And, by the way it could be a way to handle further configurations that cannot be achieve with appearance selectors... What do you think ?
