### PR TITLE
Background color of the background view

### DIFF
--- a/MZFormSheetController/MZFormSheetController.h
+++ b/MZFormSheetController/MZFormSheetController.h
@@ -90,16 +90,10 @@ typedef void(^MZFormSheetTransitionCompletionHandler)();
 @property (nonatomic, assign) MZFormSheetTransitionStyle transitionStyle UI_APPEARANCE_SELECTOR;
 
 /**
- Background view style.
- By default, this is MZFormSheetBackgroundStyleSolid.
+ The background color of the background view.
+ By default, this is a black at with a 0.5 alpha component
  */
-@property (nonatomic, assign) MZFormSheetBackgroundStyle backgroundStyle UI_APPEARANCE_SELECTOR;
-
-/**
- The opacity of the background view.
- By default, this is 0.5
- */
-@property (nonatomic, assign) CGFloat backgroundOpacity UI_APPEARANCE_SELECTOR;
+@property (nonatomic, strong) UIColor *backgroundColor UI_APPEARANCE_SELECTOR;
 
 /**
  The handler to call when presented form sheet is before entry transition and its view will show on window.

--- a/MZFormSheetController/MZFormSheetController.m
+++ b/MZFormSheetController/MZFormSheetController.m
@@ -148,22 +148,19 @@ static NSMutableDictionary *instanceOfDictionaryClasses = nil;
 #pragma mark - MZFormSheetBackgroundWindow
 
 @interface MZFormSheetBackgroundWindow : UIWindow
-@property (nonatomic, assign) MZFormSheetBackgroundStyle backgroundStyle;
-@property (nonatomic, assign) CGFloat opacity;
 
-+ (void)showBackgroundWindowAnimated:(BOOL)animated withStyle:(MZFormSheetBackgroundStyle)style opacity:(CGFloat)opacity;
++ (void)showBackgroundWindowAnimated:(BOOL)animated withBackgroundColor:(UIColor *)backgroundColor;
 + (void)hideBackgroundWindowAnimated:(BOOL)animated;
 
 @end
 
 @implementation MZFormSheetBackgroundWindow
 
-+ (void)showBackgroundWindowAnimated:(BOOL)animated withStyle:(MZFormSheetBackgroundStyle)style opacity:(CGFloat)opacity
++ (void)showBackgroundWindowAnimated:(BOOL)animated withBackgroundColor:(UIColor *)backgroundColor
 {
     if (!instanceOfFormSheetBackgroundWindow) {
         instanceOfFormSheetBackgroundWindow = [[MZFormSheetBackgroundWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-        instanceOfFormSheetBackgroundWindow.backgroundStyle = style;
-        instanceOfFormSheetBackgroundWindow.opacity = opacity;
+        instanceOfFormSheetBackgroundWindow.backgroundColor = backgroundColor;
         [instanceOfFormSheetBackgroundWindow makeKeyAndVisible];
         instanceOfFormSheetBackgroundWindow.alpha = 0;
         if (animated) {
@@ -205,15 +202,6 @@ static NSMutableDictionary *instanceOfDictionaryClasses = nil;
     return self;
 }
 
-- (void)drawRect:(CGRect)rect
-{
-    if (self.backgroundStyle == MZFormSheetBackgroundStyleSolid) {
-        CGContextRef context = UIGraphicsGetCurrentContext();
-        [[UIColor colorWithWhite:0 alpha:self.opacity] set];
-        CGContextFillRect(context, self.bounds);
-    }
-}
-
 @end
 
 #pragma mark - MZFormSheetController
@@ -245,8 +233,7 @@ static NSMutableDictionary *instanceOfDictionaryClasses = nil;
         id appearance = [[self class] appearance];
         
         [appearance setPresentedFormSheetSize:CGSizeMake(MZFormSheetControllerDefaultWidth, MZFormSheetControllerDefaultHeight)];
-        [appearance setBackgroundStyle:MZFormSheetBackgroundStyleSolid];
-        [appearance setBackgroundOpacity:MZFormSheetControllerDefaultBackgroundOpacity];
+        [appearance setBackgroundColor:[UIColor colorWithWhite:0 alpha:MZFormSheetControllerDefaultBackgroundOpacity]];
         [appearance setCornerRadius:MZFormSheetPresentedControllerDefaultCornerRadius];
         [appearance setShadowOpacity:MZFormSheetPresentedControllerDefaultShadowOpacity];
         [appearance setShadowRadius:MZFormSheetPresentedControllerDefaultShadowRadius];
@@ -372,7 +359,7 @@ static NSMutableDictionary *instanceOfDictionaryClasses = nil;
     
     [MZFormSheetController setAnimating:YES];
     
-    [MZFormSheetBackgroundWindow showBackgroundWindowAnimated:animated withStyle:self.backgroundStyle opacity:self.backgroundOpacity];
+    [MZFormSheetBackgroundWindow showBackgroundWindowAnimated:animated withBackgroundColor:self.backgroundColor];
     
     [self.formSheetWindow makeKeyAndVisible];
     


### PR DESCRIPTION
Just a wondering, why not replace the `backgroundStyle` and `backgroundOpacity` with one property `backgroundColor` ? 

Because an instance of `UIColor` has an alpha parameter and will be transparent if we use `[UIColor clearColor]`.

I just want to use another color as the background, and so it could be useful to simply the API here, but maybe you've already been through this idea, let me know.

Cheers
