### PR TITLE
Solved issue of blurred image moving up when taken without a navigation controller

### DIFF
--- a/Example/MZFormSheetControllerExample/MZFormSheetControllerExample/MZViewController.m
+++ b/Example/MZFormSheetControllerExample/MZFormSheetControllerExample/MZViewController.m
@@ -24,6 +24,7 @@
     [[MZFormSheetController appearance] setCornerRadius:20.0];
     [[MZFormSheetBackgroundWindow appearance] setBackgroundColor:[UIColor clearColor]];
     [[MZFormSheetBackgroundWindow appearance] setBackgroundBlurEffect:YES];
+    // [[MZFormSheetBackgroundWindow appearance] setShouldBackgroundImageOverlapStatusBar:YES];
 }
 
 - (void)transitionFromTop

--- a/Example/MZFormSheetControllerExample/MZFormSheetControllerExample/en.lproj/MainStoryboard_iPhone.storyboard
+++ b/Example/MZFormSheetControllerExample/MZFormSheetControllerExample/en.lproj/MainStoryboard_iPhone.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="2.0" toolsVersion="3084" systemVersion="12E55" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" initialViewController="cec-mL-RLp">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="2.0" toolsVersion="3084" systemVersion="12E55" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" initialViewController="lE3-Z0-KZW">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="2083"/>
     </dependencies>
@@ -661,12 +661,22 @@
         </class>
         <class className="MZModalViewController" superclassName="UIViewController">
             <source key="sourceIdentifier" type="project" relativePath="./Classes/MZModalViewController.h"/>
+            <relationships>
+                <relationship kind="action" name="modal:"/>
+            </relationships>
         </class>
         <class className="MZNavViewController" superclassName="UITableViewController">
             <source key="sourceIdentifier" type="project" relativePath="./Classes/MZNavViewController.h"/>
+            <relationships>
+                <relationship kind="action" name="close:"/>
+            </relationships>
         </class>
         <class className="MZSampleViewController" superclassName="UIViewController">
             <source key="sourceIdentifier" type="project" relativePath="./Classes/MZSampleViewController.h"/>
+            <relationships>
+                <relationship kind="action" name="close:"/>
+                <relationship kind="action" name="modal:"/>
+            </relationships>
         </class>
         <class className="MZViewController" superclassName="UITableViewController">
             <source key="sourceIdentifier" type="project" relativePath="./Classes/MZViewController.h"/>

--- a/MZFormSheetController/MZFormSheetBackgroundWindow.m
+++ b/MZFormSheetController/MZFormSheetBackgroundWindow.m
@@ -36,8 +36,36 @@ static UIInterfaceOrientationMask const UIInterfaceOrientationMaskFromOrientatio
 
 - (UIImage *)screenshotWithStatusBar:(BOOL)includeStatusBar
 {
+    
+    
+    
     UIGraphicsBeginImageContext(self.bounds.size);
-    [self.layer renderInContext:UIGraphicsGetCurrentContext()];
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    // Iterate over every window from back to front
+    for (UIWindow *window in [[UIApplication sharedApplication] windows])
+    {
+        if (![window respondsToSelector:@selector(screen)] || [window screen] == [UIScreen mainScreen])
+        {
+            // -renderInContext: renders in the coordinate space of the layer,
+            // so we must first apply the layer's geometry to the graphics context
+            CGContextSaveGState(context);
+            // Center the context around the window's anchor point
+            CGContextTranslateCTM(context, [window center].x, [window center].y);
+            // Apply the window's transform about the anchor point
+            CGContextConcatCTM(context, [window transform]);
+            // Offset by the portion of the bounds left of and above the anchor point
+            CGContextTranslateCTM(context,
+                                  -[window bounds].size.width * [[window layer] anchorPoint].x,
+                                  -[window bounds].size.height * [[window layer] anchorPoint].y);
+            
+            // Render the layer hierarchy to the current context
+            [[window layer] renderInContext:context];
+            
+            // Restore the context
+            CGContextRestoreGState(context);
+        }
+    }
+    //[self.layer renderInContext:UIGraphicsGetCurrentContext()];
     UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
     NSData *imageData = UIImageJPEGRepresentation(image, 0.75);


### PR DESCRIPTION
The issue was with the status bar, where the view moves up to fill in the gap when there isn't a navigation controller.
What I did was that I iterated over every window, because the status bar is in it's own window. It's still not perfect because the blurred image still looks stretched when there isn't a navigation controller.
