### PR TITLE
Use iOS7's much faster method for capturing screenshots, if it's available

### DIFF
--- a/MZFormSheetController/MZFormSheetBackgroundWindow.m
+++ b/MZFormSheetController/MZFormSheetBackgroundWindow.m
@@ -111,7 +111,11 @@ static UIInterfaceOrientationMask const UIInterfaceOrientationMaskFromOrientatio
                                   -[window bounds].size.height * [[window layer] anchorPoint].y);
 
             // Render the layer hierarchy to the current context
-            [[window layer] renderInContext:context];
+            if ([UIWindow instancesRespondToSelector:@selector(drawViewHierarchyInRect:afterScreenUpdates:)]) {
+                [window drawViewHierarchyInRect:[window bounds] afterScreenUpdates:YES];
+            } else {
+                [[window layer] renderInContext:context];
+            }
 
             // Restore the context
             CGContextRestoreGState(context);


### PR DESCRIPTION
Can't find the original Apple source for the slide on performance gains from using this iOS 7 method when taking screenshots, but it's screen capped and discussed [here](http://damir.me/ios7-blurring-techniques).
