### PR TITLE
Top inset is now taken into account in certain cases

### DIFF
--- a/Example/MZFormSheetControllerExample/MZFormSheetControllerExample/MZViewController.m
+++ b/Example/MZFormSheetControllerExample/MZFormSheetControllerExample/MZViewController.m
@@ -170,7 +170,7 @@
     formSheet.cornerRadius = 8.0;
     formSheet.portraitTopInset = 54.0;
     formSheet.presentedFormSheetSize = CGSizeMake(280, 180);
-    formSheet.shouldCenterVerticallyWhenKeyboardAppears = YES;
+    formSheet.keyboardMovementStyle = MZFormSheetKeyboardMovementStyleCenterVertically;
     
     [formSheet presentAnimated:YES completionHandler:nil];
 }

--- a/Example/Xcode5 iOS 7 Example/Xcode5Example/Xcode5Example/Base.lproj/Main_iPad.storyboard
+++ b/Example/Xcode5 iOS 7 Example/Xcode5Example/Xcode5Example/Base.lproj/Main_iPad.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="4514" systemVersion="13A603" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" useAutolayout="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="4514" systemVersion="13B42" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" useAutolayout="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3747"/>
     </dependencies>
@@ -16,8 +16,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7jf-Xo-5sz">
-                                <rect key="frame" x="348" y="554" width="46" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7jf-Xo-5sz">
+                                <rect key="frame" x="361" y="701" width="46" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
@@ -27,16 +27,21 @@
                                 </connections>
                             </button>
                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="map" translatesAutoresizingMaskIntoConstraints="NO" id="gUc-zf-UdX">
-                                <rect key="frame" x="39" y="50" width="662" height="578"/>
+                                <rect key="frame" x="53" y="50" width="662" height="578"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="662" id="GZ1-2Q-MYp"/>
+                                    <constraint firstAttribute="height" constant="578" id="WaX-i7-vqf"/>
+                                </constraints>
                             </imageView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="VJw-YZ-pQN" firstAttribute="top" secondItem="gUc-zf-UdX" secondAttribute="bottom" constant="396" id="9dP-4H-NYi"/>
+                            <constraint firstAttribute="centerX" secondItem="7jf-Xo-5sz" secondAttribute="centerX" id="2Yp-at-HER"/>
+                            <constraint firstAttribute="centerX" secondItem="gUc-zf-UdX" secondAttribute="centerX" id="OXD-CZ-ITv"/>
                             <constraint firstItem="gUc-zf-UdX" firstAttribute="top" secondItem="P9t-f5-GxB" secondAttribute="bottom" constant="30" id="Qur-hi-0MX"/>
-                            <constraint firstAttribute="trailing" secondItem="gUc-zf-UdX" secondAttribute="trailing" constant="67" id="SR8-Qf-j82"/>
-                            <constraint firstItem="gUc-zf-UdX" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" constant="39" id="aky-Ow-4A0"/>
+                            <constraint firstItem="7jf-Xo-5sz" firstAttribute="top" secondItem="gUc-zf-UdX" secondAttribute="bottom" constant="73" id="bAC-Pl-5Kd"/>
+                            <constraint firstItem="VJw-YZ-pQN" firstAttribute="top" relation="greaterThanOrEqual" secondItem="7jf-Xo-5sz" secondAttribute="bottom" constant="20" id="eq2-iA-SJd"/>
                         </constraints>
                     </view>
                 </viewController>
@@ -59,21 +64,19 @@
                                 <rect key="frame" x="0.0" y="71" width="320" height="160"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="320" id="wR0-8l-18R"/>
+                                    <constraint firstAttribute="height" constant="160" id="P0x-ia-PEy"/>
+                                    <constraint firstAttribute="width" constant="320" id="XEM-5C-elO"/>
                                 </constraints>
                             </imageView>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="buttons" translatesAutoresizingMaskIntoConstraints="NO" id="JO3-er-ZKi">
-                                <rect key="frame" x="0.0" y="236" width="320" height="59"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="59" id="YqJ-zv-03g"/>
-                                </constraints>
-                            </imageView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eex-4o-VUc">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eex-4o-VUc">
                                 <rect key="frame" x="0.0" y="239" width="320" height="59"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="320" id="cOw-v3-Loy"/>
+                                    <constraint firstAttribute="height" constant="59" id="gxO-fd-qUa"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <state key="normal">
+                                <state key="normal" backgroundImage="buttons">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
                                 <connections>
@@ -83,23 +86,18 @@
                         </subviews>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="fo8-Pg-8N0" firstAttribute="top" secondItem="eex-4o-VUc" secondAttribute="bottom" constant="726" id="5x0-BK-sTk"/>
-                            <constraint firstItem="eex-4o-VUc" firstAttribute="leading" secondItem="JO3-er-ZKi" secondAttribute="leading" id="H66-ME-JZh"/>
-                            <constraint firstItem="JO3-er-ZKi" firstAttribute="trailing" secondItem="cOB-n4-rTB" secondAttribute="trailing" id="Hce-jz-ram"/>
-                            <constraint firstItem="JO3-er-ZKi" firstAttribute="leading" secondItem="cOB-n4-rTB" secondAttribute="leading" id="UT8-pT-Fep"/>
-                            <constraint firstItem="JO3-er-ZKi" firstAttribute="top" secondItem="cOB-n4-rTB" secondAttribute="bottom" constant="5" id="WqI-CE-ywe"/>
-                            <constraint firstItem="JO3-er-ZKi" firstAttribute="trailing" secondItem="eex-4o-VUc" secondAttribute="trailing" id="gJe-NJ-Jff"/>
+                            <constraint firstItem="cOB-n4-rTB" firstAttribute="leading" secondItem="hEz-uv-fwe" secondAttribute="leading" id="JpC-vQ-OTx"/>
                             <constraint firstItem="cOB-n4-rTB" firstAttribute="top" secondItem="ayj-Ny-0oZ" secondAttribute="bottom" constant="7" id="jP3-JC-caY"/>
                             <constraint firstItem="eex-4o-VUc" firstAttribute="top" secondItem="cOB-n4-rTB" secondAttribute="bottom" constant="8" symbolic="YES" id="ko3-hi-h8d"/>
-                            <constraint firstItem="fo8-Pg-8N0" firstAttribute="top" secondItem="JO3-er-ZKi" secondAttribute="bottom" constant="729" id="qnL-I9-Qd6"/>
                             <constraint firstItem="eex-4o-VUc" firstAttribute="leading" secondItem="hEz-uv-fwe" secondAttribute="leading" id="vtz-Jz-xHe"/>
+                            <constraint firstItem="eex-4o-VUc" firstAttribute="centerX" secondItem="cOB-n4-rTB" secondAttribute="centerX" id="xeD-Uk-JvR"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="Calendar" id="Dhb-Xc-f0Q"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="qiU-Rp-WHR" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1381" y="189"/>
+            <point key="canvasLocation" x="1877" y="-94"/>
         </scene>
         <!--Table View Controller-->
         <scene sceneID="9UG-ec-XlN">
@@ -191,7 +189,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="u3B-2D-w2Y" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1778" y="188"/>
+            <point key="canvasLocation" x="2770" y="-94"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="Axo-gT-tHR">
@@ -209,7 +207,7 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="8iL-mQ-5Ww" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1877" y="390"/>
+            <point key="canvasLocation" x="1001" y="-94"/>
         </scene>
     </scenes>
     <resources>

--- a/Example/Xcode5 iOS 7 Example/Xcode5Example/Xcode5Example/MZViewController.m
+++ b/Example/Xcode5 iOS 7 Example/Xcode5Example/Xcode5Example/MZViewController.m
@@ -33,14 +33,19 @@
     UIViewController *vc = [self.storyboard instantiateViewControllerWithIdentifier:@"modal"];
     
     MZFormSheetController *formSheet = [[MZFormSheetController alloc] initWithViewController:vc];
-    
+  
+    formSheet.presentedFormSheetSize = CGSizeMake(320, 298);
     formSheet.transitionStyle = MZFormSheetTransitionStyleSlideFromTop;
     formSheet.shadowRadius = 2.0;
     formSheet.shadowOpacity = 0.3;
     formSheet.shouldDismissOnBackgroundViewTap = YES;
-    formSheet.shouldCenterVerticallyWhenKeyboardAppears = YES;
-//    formSheet.shouldMoveToTopWhenKeyboardAppears = NO;
-
+    formSheet.shouldCenterVertically = YES;
+    formSheet.keyboardMovementStyle = MZFormSheetKeyboardMovementStyleCenterVertically;
+    // formSheet.keyboardMovementStyle = MZFormSheetKeyboardMovementStyleMoveToTop;
+    // formSheet.keyboardMovementStyle = MZFormSheetKeyboardMovementStyleMoveToTopInset;
+    // formSheet.landscapeTopInset = 50;
+    // formSheet.portraitTopInset = 100;
+  
     __weak MZFormSheetController *weakFormSheet = formSheet;
 
 

--- a/MZFormSheetController/MZFormSheetController.h
+++ b/MZFormSheetController/MZFormSheetController.h
@@ -51,6 +51,13 @@ typedef NS_ENUM(NSInteger, MZFormSheetTransitionStyle) {
     MZFormSheetTransitionStyleNone,
 };
 
+typedef NS_ENUM(NSInteger, MZFormSheetKeyboardMovementStyle) {
+  MZFormSheetKeyboardMovementStyleMoveToTop = 0,
+  MZFormSheetKeyboardMovementStyleMoveToTopInset,
+  MZFormSheetKeyboardMovementStyleCenterVertically,
+  MZFormSheetKeyboardMovementStyleNone,
+};
+
 /**
  Notifications are posted right after completion handlers
  
@@ -129,6 +136,12 @@ typedef void(^MZFormSheetTransitionCompletionHandler)();
 @property (nonatomic, assign) MZFormSheetTransitionStyle transitionStyle MZ_APPEARANCE_SELECTOR;
 
 /**
+ The movement style to use when the keyboard appears.
+ By default, this is MZFormSheetKeyboardMovementStyleMoveToTop.
+ */
+@property (nonatomic, assign) MZFormSheetKeyboardMovementStyle keyboardMovementStyle MZ_APPEARANCE_SELECTOR;
+
+/**
  The handler to call when presented form sheet is before entry transition and its view will show on window.
  */
 @property (nonatomic, copy) MZFormSheetCompletionHandler willPresentCompletionHandler;
@@ -200,18 +213,6 @@ typedef void(^MZFormSheetTransitionCompletionHandler)();
  By default, this is NO
  */
 @property (nonatomic, assign) BOOL shouldDismissOnBackgroundViewTap MZ_APPEARANCE_SELECTOR;
-
-/**
- Returns whether the form sheet controller should move to top when UIKeyboard will appear.
- By default, this is YES
- */
-@property (nonatomic, assign) BOOL shouldMoveToTopWhenKeyboardAppears MZ_APPEARANCE_SELECTOR;
-
-/**
- Center form sheet vertically when UIKeyboard will appear.
- By default, this is NO
- */
-@property (nonatomic, assign) BOOL shouldCenterVerticallyWhenKeyboardAppears MZ_APPEARANCE_SELECTOR;
 
 /**
  Subclasses may override to add custom transition animation.


### PR DESCRIPTION
The top inset (landscape or portrait) is now used to calculate the `top`
when `shouldMoveToTopWhenKeyboardAppears` is set to `YES`. This is only
applicable when the form sheet can fit in the screen’s frame when the keyboard
is visible - otherwise `top` is defined as `0` or `statusBarHeight` so that as
much of the form sheet as possible is visible.

This gives the user additional flexibility as they can decide how far up a given form sheet should appear when the keyboard is present.
