### PR TITLE
[rex-remind101/keyboard-animation-fix] Smooths out the animation transition

### DIFF
--- a/MZFormSheetController/MZFormSheetController.m
+++ b/MZFormSheetController/MZFormSheetController.m
@@ -706,9 +706,9 @@ static BOOL MZFromSheetControllerIsViewControllerBasedStatusBarAppearance(void) 
     self.screenFrameWhenKeyboardVisible = [NSValue valueWithCGRect:screenRect];
     self.keyboardVisible = YES;
 
-    [UIView animateWithDuration:MZFormSheetControllerDefaultAnimationDuration animations:^{
+    [UIView animateWithDuration:MZFormSheetControllerDefaultAnimationDuration delay:0.0 options:UIViewAnimationOptionBeginFromCurrentState animations:^{
         [self setupPresentedFSViewControllerFrame];
-    }];
+    } completion:nil];
     
 }
 
@@ -717,9 +717,9 @@ static BOOL MZFromSheetControllerIsViewControllerBasedStatusBarAppearance(void) 
     self.keyboardVisible = NO;
     self.screenFrameWhenKeyboardVisible = nil;
     
-    [UIView animateWithDuration:MZFormSheetControllerDefaultAnimationDuration animations:^{
+    [UIView animateWithDuration:MZFormSheetControllerDefaultAnimationDuration delay:0.0 options:UIViewAnimationOptionBeginFromCurrentState animations:^{
         [self setupPresentedFSViewControllerFrame];
-    }];
+    } completion:nil];
 
 }
 


### PR DESCRIPTION
Smooths out the animation transitions between multiple different keyboards during quick position changes from `becomeFirstResponder` calls.

When `[view becomeFirstResponder]` is called quickly amongst multiple views with multiple keyboards, the form sheet controller will bounce indiscriminately from changes in position. This bit of code prevents that bounce from occurring and smooths out all keyboard transitions in general.
