### PR TITLE
Only swap screen & keyboard width/height prior to iOS 8. In iOS 8 the ke...

### DIFF
--- a/MZFormSheetController/MZFormSheetController.m
+++ b/MZFormSheetController/MZFormSheetController.m
@@ -730,8 +730,8 @@ static BOOL MZFromSheetControllerIsViewControllerBasedStatusBarAppearance(void) 
 - (void)willShowKeyboardNotification:(NSNotification *)notification
 {
     CGRect screenRect = [[notification userInfo][UIKeyboardFrameEndUserInfoKey] CGRectValue];
-
-    if (UIDeviceOrientationIsLandscape([UIApplication sharedApplication].statusBarOrientation)) {
+    
+    if (UIDeviceOrientationIsLandscape([UIApplication sharedApplication].statusBarOrientation) && MZSystemVersionLessThan_iOS8()) {
         screenRect.size.height = [UIScreen mainScreen].bounds.size.width - screenRect.size.width;
         screenRect.size.width = [UIScreen mainScreen].bounds.size.height;
     } else {


### PR DESCRIPTION
...yboard frame and the screen bounds are maintained in a rotation dependant state.
