### PR TITLE
Remove iOS 4 check

### DIFF
--- a/MZFormSheetController/MZFormSheetBackgroundWindow.m
+++ b/MZFormSheetController/MZFormSheetBackgroundWindow.m
@@ -89,13 +89,7 @@ static UIInterfaceOrientationMask const UIInterfaceOrientationMaskFromOrientatio
 + (UIImage *)screenshotUsingContext:(BOOL)useContext
 {
     // Create a graphics context with the target size
-    // On iOS 4 and later, use UIGraphicsBeginImageContextWithOptions to take the scale into consideration
-    // On iOS prior to 4, fall back to use UIGraphicsBeginImageContext
-    CGSize imageSize = [[UIScreen mainScreen] bounds].size;
-    if (NULL != UIGraphicsBeginImageContextWithOptions)
-        UIGraphicsBeginImageContextWithOptions(imageSize, NO, 0);
-    else
-        UIGraphicsBeginImageContext(imageSize);
+    UIGraphicsBeginImageContextWithOptions([[UIScreen mainScreen] bounds].size, NO, 0);
 
     CGContextRef context = UIGraphicsGetCurrentContext();
 


### PR DESCRIPTION
Remove iOS 4 check, since MZFormSheetController requires either iOS 5.x or above.
