### PR TITLE
[fix] Updating blur only on interface orientation change

### DIFF
--- a/MZFormSheetController/MZFormSheetBackgroundWindow.m
+++ b/MZFormSheetController/MZFormSheetBackgroundWindow.m
@@ -57,6 +57,7 @@ static UIInterfaceOrientationMask const UIInterfaceOrientationMaskFromOrientatio
 @interface MZFormSheetBackgroundWindow()
 @property (nonatomic, strong) UIImageView *backgroundImageView;
 @property (nonatomic, assign, getter = isUpdatingBlur) BOOL updatingBlur;
+@property (nonatomic, assign) UIInterfaceOrientation lastWindowOrientation;
 @end
 
 @implementation MZFormSheetBackgroundWindow
@@ -226,6 +227,8 @@ static UIInterfaceOrientationMask const UIInterfaceOrientationMaskFromOrientatio
 
         [self rotateWindow];
 
+        self.lastWindowOrientation = [self windowOrientation];
+        
         [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
 
         [[NSNotificationCenter defaultCenter] addObserver:self
@@ -261,7 +264,9 @@ static UIInterfaceOrientationMask const UIInterfaceOrientationMaskFromOrientatio
 {
     [self rotateWindow];
 
-    if (self.backgroundBlurEffect) {
+    UIInterfaceOrientation windowOrientation = [self windowOrientation];
+    if (self.backgroundBlurEffect && windowOrientation != self.lastWindowOrientation) {
+        self.lastWindowOrientation = windowOrientation;
         [self updateBlurUsingContext:YES];
     }
 


### PR DESCRIPTION
This is the fix for #126. 

It seems that I haven't provided enough information in that issue, so I attach a small [video](https://www.dropbox.com/s/1q1gnblrjygbc8t/%D0%92%D0%B8%D0%B4%D0%B5%D0%BE%2023.12.14%2C%2022%2033%2012.mov?dl=0) that describes it, here are the steps:
1. Run example project on any device (there is an iPad on the video though). 
2. Put NSLog or breakpoint on top of `didOrientationChangeNotificationHandler:` method of `MZFormSheetBackgroundWindow` class to output device orientation whenever it changes.
3. Move device as shown on the video
4. See the console

As you see method is called when interface orientation doesn't change, so if blur enabled this wastes device memory and power. Simply putting blur updating to `didChangeStatusBarOrientationNotificationHandler` results in incorrect background rendering during rotation on iOS 7, so I've come up with this quick and dirty fix. 
