### PR TITLE
Bug Fix & MZFormSheetWhenKeyboardAppearsMoveAboveKeyboard

### DIFF
--- a/MZFormSheetController/MZFormSheetController.h
+++ b/MZFormSheetController/MZFormSheetController.h
@@ -38,6 +38,7 @@ typedef NS_ENUM(NSInteger, MZFormSheetWhenKeyboardAppears) {
   MZFormSheetWhenKeyboardAppearsCenterVertically,
   MZFormSheetWhenKeyboardAppearsMoveToTop,
   MZFormSheetWhenKeyboardAppearsMoveToTopInset,
+  MZFormSheetWhenKeyboardAppearsMoveAboveKeyboard
 };
 
 /**

--- a/MZFormSheetController/MZFormSheetController.m
+++ b/MZFormSheetController/MZFormSheetController.m
@@ -669,7 +669,7 @@ static BOOL MZFromSheetControllerIsViewControllerBasedStatusBarAppearance(void) 
         CGRect formSheetRect = self.presentedFSViewController.view.frame;
         CGRect screenRect = [self.screenFrameWhenKeyboardVisible CGRectValue];
 
-        if (screenRect.size.height > formSheetRect.size.height) {
+        if (screenRect.size.height < CGRectGetMaxY(formSheetRect))) {
           switch (self.movementWhenKeyboardAppears) {
             case MZFormSheetWhenKeyboardAppearsCenterVertically:
               formSheetRect.origin.y = ([MZFormSheetController statusBarHeight] + screenRect.size.height - formSheetRect.size.height)/2 - screenRect.origin.y;
@@ -680,6 +680,8 @@ static BOOL MZFromSheetControllerIsViewControllerBasedStatusBarAppearance(void) 
             case MZFormSheetWhenKeyboardAppearsMoveToTopInset:
               formSheetRect.origin.y = self.topInset;
               break;
+            case MZFormSheetWhenKeyboardAppearsMoveAboveKeyboard:
+              formSheetRect.origin.y = formSheetRect.origin.y + (screenRect.size.height - CGRectGetMaxY(formSheetRect));
             default:
               break;
           }

--- a/MZFormSheetController/MZFormSheetController.m
+++ b/MZFormSheetController/MZFormSheetController.m
@@ -50,6 +50,8 @@ CGFloat const MZFormSheetPresentedControllerDefaultCornerRadius = 6.0;
 CGFloat const MZFormSheetPresentedControllerDefaultShadowRadius = 6.0;
 CGFloat const MZFormSheetPresentedControllerDefaultShadowOpacity = 0.5;
 
+CGFloat const MZFormSheetKeyboardMargin = 20.0;
+
 CGFloat const MZFormSheetControllerWindowTag = 10001;
 
 static const char* MZFormSheetControllerAssociatedKey = "MZFormSheetControllerAssociatedKey";
@@ -668,27 +670,27 @@ static BOOL MZFromSheetControllerIsViewControllerBasedStatusBarAppearance(void) 
     if (self.keyboardVisible && self.movementWhenKeyboardAppears != MZFormSheetWhenKeyboardAppearsDoNothing) {
         CGRect formSheetRect = self.presentedFSViewController.view.frame;
         CGRect screenRect = [self.screenFrameWhenKeyboardVisible CGRectValue];
-
-        if (screenRect.size.height < CGRectGetMaxY(formSheetRect))) {
-          switch (self.movementWhenKeyboardAppears) {
-            case MZFormSheetWhenKeyboardAppearsCenterVertically:
-              formSheetRect.origin.y = ([MZFormSheetController statusBarHeight] + screenRect.size.height - formSheetRect.size.height)/2 - screenRect.origin.y;
-              break;
-            case MZFormSheetWhenKeyboardAppearsMoveToTop:
-              formSheetRect.origin.y = self.top;
-              break;
-            case MZFormSheetWhenKeyboardAppearsMoveToTopInset:
-              formSheetRect.origin.y = self.topInset;
-              break;
-            case MZFormSheetWhenKeyboardAppearsMoveAboveKeyboard:
-              formSheetRect.origin.y = formSheetRect.origin.y + (screenRect.size.height - CGRectGetMaxY(formSheetRect));
-            default:
-              break;
-          }
+        
+        if (screenRect.size.height < CGRectGetMaxY(formSheetRect)) {
+            switch (self.movementWhenKeyboardAppears) {
+                case MZFormSheetWhenKeyboardAppearsCenterVertically:
+                    formSheetRect.origin.y = ([MZFormSheetController statusBarHeight] + screenRect.size.height - formSheetRect.size.height)/2 - screenRect.origin.y;
+                    break;
+                case MZFormSheetWhenKeyboardAppearsMoveToTop:
+                    formSheetRect.origin.y = self.top;
+                    break;
+                case MZFormSheetWhenKeyboardAppearsMoveToTopInset:
+                    formSheetRect.origin.y = self.topInset;
+                    break;
+                case MZFormSheetWhenKeyboardAppearsMoveAboveKeyboard:
+                    formSheetRect.origin.y = formSheetRect.origin.y + (screenRect.size.height - CGRectGetMaxY(formSheetRect)) - MZFormSheetKeyboardMargin;
+                default:
+                    break;
+            }
         } else {
-          formSheetRect.origin.y = self.top;
+            formSheetRect.origin.y = self.top;
         }
-
+        
         self.presentedFSViewController.view.frame = formSheetRect;
     } else if (self.shouldCenterVertically) {
         self.presentedFSViewController.view.center = CGPointMake(CGRectGetMidX(self.view.bounds), CGRectGetMidY(self.view.bounds));


### PR DESCRIPTION
This library is great, but I encountered a minor issue moving centered windows when the keyboard is shown. The y position of the window is ignored, so windows that are not positioned at y=0 might not get moved when the Keyboard comes in.

I also found that I wanted to stack over-flowing windows above the keyboard so I added MZFormSheetWhenKeyboardAppearsMoveAboveKeyboard.
 