### PR TITLE
Fix problem with changing sheet size while animating.

### DIFF
--- a/MZFormSheetController/MZFormSheetController.m
+++ b/MZFormSheetController/MZFormSheetController.m
@@ -391,7 +391,7 @@ static BOOL MZFromSheetControllerIsViewControllerBasedStatusBarAppearance(void) 
         
         CGPoint presentedFormCenter = self.presentedFSViewController.view.center;
         self.presentedFSViewController.view.frame = CGRectMake(presentedFormCenter.x - _presentedFormSheetSize.width / 2,
-                                                               presentedFormCenter.y - presentedFormSheetSize.height / 2,
+                                                               presentedFormCenter.y - _presentedFormSheetSize.height / 2,
                                                                _presentedFormSheetSize.width,
                                                                _presentedFormSheetSize.height);
         self.presentedFSViewController.view.center = presentedFormCenter;

--- a/MZFormSheetController/MZFormSheetController.m
+++ b/MZFormSheetController/MZFormSheetController.m
@@ -390,7 +390,10 @@ static BOOL MZFromSheetControllerIsViewControllerBasedStatusBarAppearance(void) 
         _presentedFormSheetSize = CGSizeMake(nearbyintf(presentedFormSheetSize.width), nearbyintf(presentedFormSheetSize.height));
         
         CGPoint presentedFormCenter = self.presentedFSViewController.view.center;
-        self.presentedFSViewController.view.frame = CGRectMake(0, 0, _presentedFormSheetSize.width, _presentedFormSheetSize.height);
+        self.presentedFSViewController.view.frame = CGRectMake(presentedFormCenter.x - _presentedFormSheetSize.width / 2,
+                                                               presentedFormCenter.y - presentedFormSheetSize.height / 2,
+                                                               _presentedFormSheetSize.width,
+                                                               _presentedFormSheetSize.height);
         self.presentedFSViewController.view.center = presentedFormCenter;
         
         // This will make sure that origin be in good position

--- a/MZFormSheetController/MZFormSheetPresentationController/MZFormSheetPresentationController.m
+++ b/MZFormSheetController/MZFormSheetPresentationController/MZFormSheetPresentationController.m
@@ -104,7 +104,10 @@ static NSMutableDictionary *_instanceOfTransitionClasses = nil;
         _contentViewSize = CGSizeMake(nearbyintf(contentViewSize.width), nearbyintf(contentViewSize.height));
 
         CGPoint center = self.contentViewController.view.center;
-        self.contentViewController.view.frame = CGRectMake(0, 0, _contentViewSize.width, _contentViewSize.height);
+        self.contentViewController.view.frame = CGRectMake(center.x - _contentViewController.width / 2,
+                                                           center.y - _contentViewController.height / 2, 
+                                                           _contentViewSize.width, 
+                                                           _contentViewSize.height);
         self.contentViewController.view.center = center;
         [self setupFormSheetViewControllerFrame];
     }


### PR DESCRIPTION
When using setPresentedFormSheetSize: while animating, formController jumps to the top left corner and then continue animation to the center.